### PR TITLE
use ant-javacard for compilation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "oracle_javacard_sdks"]
+	path = oracle_javacard_sdks
+	url = git@github.com:martinpaljak/oracle_javacard_sdks.git

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,10 @@
   <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ant-javacard.jar"/>
   <target name="applet">
     <javacard>
-      <cap aid="A0:00:00:06:17:00:EC:5E:FF:D8" output="PGP.cap" sources="applet/src">
+      <cap jckit="oracle_javacard_sdks/jc222_kit" aid="A0:00:00:06:17:00:EC:5E:FF:D8" output="PGP22.cap" sources="applet/src">
+        <applet class="openpgpcard.OpenPGPApplet" aid="A0:00:00:06:17:00:EC:5E:FF:D8:00:00:00:01:00:00"/>
+      </cap>
+      <cap jckit="oracle_javacard_sdks/jc304_kit" aid="A0:00:00:06:17:00:EC:5E:FF:D8" output="PGP30.cap" sources="applet/src">
         <applet class="openpgpcard.OpenPGPApplet" aid="A0:00:00:06:17:00:EC:5E:FF:D8:00:00:00:01:00:00"/>
       </cap>
     </javacard>

--- a/build.xml
+++ b/build.xml
@@ -1,126 +1,13 @@
 <?xml version="1.0"?>
-<project name="ykneo-openpgp" default="convert" basedir="." xmlns:jacoco="antlib:org.jacoco.ant">
+<project name="ykneo-openpgp" default="applet" basedir=".">
+  <get src="https://github.com/martinpaljak/ant-javacard/releases/download/v1.6/ant-javacard.jar" dest="."/>
   <description>Ant build for ykneo-openpgp applet</description>
-  <property name="src" location="applet/src"/>
-  <property name="build" location="applet/bin"/>
-  <property name="test.src" location="test/test"/>
-  <property name="test.build" location="test/bin"/>
-  <property name="test.lib" location="test/lib"/>
-  <!-- Load user specified extra properties -->
-  <property file="${user.home}/javacard.properties"/>
-  <property name="JAVA_PACKAGE" value="openpgpcard"/>
-  <property name="JAVA_PACKAGE_DIR" value="openpgpcard/"/>
-  <property name="APPLET_NAME" value="OpenPGPApplet"/>
-  <property name="PACKAGE_AID" value="0xd2:0x76:0x00:0x01:0x24:0x01"/>
-  <property name="APPLET_AID" value="0xd2:0x76:0x00:0x01:0x24:0x01:0x02:0x00:0x00:0x00:0x00:0x00:0x00:0x01:0x00:0x00"/>
-  <property name="VERSION" value="0.1"/>
-  <target name="init">
-    <mkdir dir="${build}"/>
-    <mkdir dir="${test.build}/output"/>
-  </target>
-  <target name="compile" depends="init" description="compile the source" unless="test.build.mock">
-    <javac srcdir="${src}" destdir="${build}" includeantruntime="false" source="1.5" target="1.5">
-      <classpath>
-        <pathelement path="${JAVACARD_HOME}/lib/api.jar"/>
-      </classpath>
-    </javac>
-  </target>
-  <target name="compileMock" depends="init" description="compile with mocked javacard" if="test.build.mock">
-    <javac srcdir="${src}" destdir="${build}" source="1.2" target="1.1" includeantruntime="false" debug="yes">
-      <classpath>
-        <fileset dir="${test.lib}">
-          <include name="*.jar"/>
-        </fileset>
-      </classpath>
-    </javac>
-  </target>
-  <target depends="compile" name="convert" description="convert to .cap" unless="test.build.mock">
-    <java classname="com.sun.javacard.converter.Converter" fork="true" failonerror="true">
-      <arg line="-classdir ${build}"/>
-      <arg line="-verbose"/>
-      <arg line="-exportpath ${JAVACARD_HOME}/api_export_files"/>
-      <arg line="-out CAP JCA EXP"/>
-      <arg line="-applet ${APPLET_AID} ${APPLET_NAME}"/>
-      <arg line="${JAVA_PACKAGE} ${PACKAGE_AID} ${VERSION}"/>
-      <classpath>
-        <pathelement location="${JAVACARD_HOME}/lib/converter.jar"/>
-        <pathelement location="${JAVACARD_HOME}/lib/offcardverifier.jar"/>
-      </classpath>
-    </java>
-  </target>
-  <target name="clean" description="clean up">
-    <delete dir="${build}"/>
-    <delete dir="${test.build}"/>
-  </target>
-  <target name="compileTest" depends="compile,compileMock">
-    <javac srcdir="${test.src}" destdir="${test.build}" includeantruntime="false">
-      <classpath>
-        <pathelement path="${build}"/>
-        <pathelement location="/usr/share/java/junit4.jar"/>
-        <fileset dir="${test.lib}">
-          <include name="*.jar"/>
-        </fileset>
-      </classpath>
-    </javac>
-  </target>
-  <target name="test" description="run tests" depends="compileTest">
-    <junit printSummary="no" fork="yes" failureproperty="junit.failure">
-      <classpath>
-        <pathelement location="${test.build}"/>
-        <pathelement path="${build}"/>
-        <pathelement location="/usr/share/java/junit4.jar"/>
-        <fileset dir="${test.lib}">
-          <include name="*.jar"/>
-        </fileset>
-      </classpath>
-      <formatter type="plain" usefile="false" />
-      <formatter type="plain" />
-      <batchtest todir="${test.build}/output">
-        <fileset dir="${test.src}" includes="**/*.java" />
-      </batchtest>
-    </junit>
-    <fail if="junit.failure" message="Unit test(s) failed.  See reports!"/>
-  </target>
-  <target name="coverage" description="run tests with coverage" depends="compileTest">
-    <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
-      <classpath>
-        <fileset dir="${test.lib}">
-          <include name="*.jar"/>
-        </fileset>
-      </classpath>
-    </taskdef>
-    <jacoco:coverage>
-      <junit printSummary="no" fork="yes" failureproperty="junit.failure">
-        <classpath>
-          <pathelement location="${test.build}"/>
-          <pathelement path="${build}"/>
-          <pathelement location="/usr/share/java/junit4.jar"/>
-          <fileset dir="${test.lib}">
-            <include name="*.jar"/>
-          </fileset>
-        </classpath>
-        <formatter type="plain" usefile="false" />
-        <formatter type="plain" />
-        <batchtest todir="${test.build}/output">
-          <fileset dir="${test.src}" includes="**/*.java" />
-        </batchtest>
-      </junit>
-    </jacoco:coverage>
-    <jacoco:report>
-      <executiondata>
-        <file file="jacoco.exec"/>
-      </executiondata>
-      <structure name="ykneo-openpgp project">
-        <classfiles>
-          <fileset dir="applet/bin"/>
-        </classfiles>
-        <sourcefiles encoding="UTF-8">
-          <fileset dir="applet/src"/>
-        </sourcefiles>
-      </structure>
-      <xml destfile="jacoco.xml"/>
-      <html destdir="jacoco"/>
-    </jacoco:report>
-    <fail if="junit.failure" message="Unit test(s) failed.  See reports!"/>
+  <taskdef name="javacard" classname="pro.javacard.ant.JavaCard" classpath="ant-javacard.jar"/>
+  <target name="applet">
+    <javacard>
+      <cap aid="A0:00:00:06:17:00:EC:5E:FF:D8" output="PGP.cap" sources="applet/src">
+        <applet class="openpgpcard.OpenPGPApplet" aid="A0:00:00:06:17:00:EC:5E:FF:D8:00:00:00:01:00:00"/>
+      </cap>
+    </javacard>
   </target>
 </project>


### PR DESCRIPTION
Using this plugin cleans A LOT the `build.xml` file.

Now it's not needed to download the Javacard SDKs globally in your machine, but you can just:

```
$ git submodule init
$ git submodule update
$ ant
```

This will produce 2 files, `PGP22.cap` and `PGP30.cap`